### PR TITLE
Use octoprint.server.http.bodysize hook to override upload size

### DIFF
--- a/octoprint_flasharduino/__init__.py
+++ b/octoprint_flasharduino/__init__.py
@@ -16,6 +16,11 @@ class FlashArduino(octoprint.plugin.TemplatePlugin,
 			       octoprint.plugin.SettingsPlugin,
 			       octoprint.plugin.BlueprintPlugin):
 
+		def bodysize_hook(self, current_max_body_sizes, *args, **kwargs):
+			return [
+				("POST", "/plugin/" + self._identifier + "/flash", 512 * 1024) # max upload size = 512KB
+			]
+
 		##~~ AssetsPlugin
 		def get_assets(self):
 			return dict(
@@ -115,5 +120,12 @@ class FlashArduino(octoprint.plugin.TemplatePlugin,
 			for line in lines:
 				self._console_logger.debug(u"{prefix} {line}".format(**locals()))
 
-__plugin_implementation__ = FlashArduino()
 __plugin_name__ = "Flash Arduino"
+def __plugin_load__():
+	global __plugin_implementation__
+	__plugin_implementation__ = FlashArduino()
+
+	global __plugin_hooks__
+	__plugin_hooks__ = {
+		"octoprint.server.http.bodysize": __plugin_implementation__.bodysize_hook
+	}


### PR DESCRIPTION
Otherwise uploads to flash endpoint will be limited to 100KB,
effectively preventing any hex file from uploading successfully.

Maximum upload size for the endpoint currently hardcoded to 512KB
(see comment), maybe adjust to chipsize or add as setting?
